### PR TITLE
First match added to clamav file changes to ensure private mirror is preferred, updating base collection to use

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -5,7 +5,7 @@ collections:
     version: 0.1.41
   - name: https://github.com/companieshouse/ansible-collections.git#/ch_collections/base/
     type: git
-    version: 0.1.77
+    version: 0.1.78
   - name: ansible.posix
     version: 1.1.1
 


### PR DESCRIPTION
First match added to clamav file changes to ensure private mirror is preferred, updating base collection to use it.
This rhel6 image can no longer retrieve updates from ClamAV public mirrors so this image now relies on the local private mirror.