### PR TITLE
moves ansible role to CH repo

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -10,7 +10,7 @@ collections:
     version: 1.1.1
 
 roles:
-  - src: christiangda.amazon_cloudwatch_agent
+  - src: https://github.com/companieshouse/ansible-role-amazon-cloudwatch-agent.git
     name: cloudwatch_agent
   - src: geerlingguy.repo-epel
     name: epel


### PR DESCRIPTION
replaces christiangda/ansible-role-amazon-cloudwatch-agent in companieshouse/rhel6-base-ami/ansible/requirements.yml

resolves DVOP-1946