### PR TITLE
Removing http:// from database mirror as freshclam doesnt seem to like it on RHEL6 only

### DIFF
--- a/ansible/host_vars/rhel6-base.yml
+++ b/ansible/host_vars/rhel6-base.yml
@@ -33,7 +33,7 @@ pip_install_packages:
   - name: selinux
     umask: "0022"
 
-clamav_mirror: http://clamav-mirror.sharedservices.aws.internal
+clamav_mirror: clamav-mirror.sharedservices.aws.internal
 
 selinux_policies:
   - antivirus_can_scan_system


### PR DESCRIPTION
Removing http:// from database mirror as freshclam doesnt seem to like it on RHEL6 only