### PR TITLE
Adding pinned version of community.general collection as later versions

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,11 +1,13 @@
 ---
 collections:
-  - name: https://github.com/companieshouse/ansible-collections.git#/ch_collections/enterpriselinux6/
-    type: git
-    version: 0.1.41
   - name: https://github.com/companieshouse/ansible-collections.git#/ch_collections/base/
     type: git
     version: 0.1.82
+  - name: https://github.com/companieshouse/ansible-collections.git#/ch_collections/enterpriselinux6/
+    type: git
+    version: 0.1.109
+  - name: community.general
+    version: 4.8.0
   - name: ansible.posix
     version: 1.1.1
 


### PR DESCRIPTION
Adding pinned version of community.general collection as later versions are incompatable with Ansible 2.10 and rhel6-cis version increase